### PR TITLE
Add NVIDIA NIM support alongside OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# ── Provider selection ────────────────────────────────────────────────────────
+# Set LLM_PROVIDER to "openai" (default) or "nvidia_nim"
+LLM_PROVIDER=openai
+
+# ── OpenAI configuration ──────────────────────────────────────────────────────
+# Used when LLM_PROVIDER=openai (or as fallback for NVIDIA NIM)
+OPENAI_API_KEY=sk-...
+
+# Optional: override the OpenAI-compatible base URL (leave unset for api.openai.com)
+# OPENAI_API_BASE=
+
+# Optional: override model names
+# CHAT_MODEL=gpt-4o-mini
+# EMBED_MODEL=text-embedding-3-small
+
+# ── NVIDIA NIM configuration ──────────────────────────────────────────────────
+# Used when LLM_PROVIDER=nvidia_nim
+# NVIDIA_API_KEY=nvapi-...
+# OPENAI_API_BASE=https://integrate.api.nvidia.com/v1
+# CHAT_MODEL=meta/llama-3.1-8b-instruct
+# EMBED_MODEL=nvidia/nv-embedqa-e5-v5

--- a/config.py
+++ b/config.py
@@ -17,14 +17,34 @@ class Config:
 
     # pylint: disable=too-few-public-methods
 
-    # API key for OpenAI services, loaded from environment variables
-    OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")  # pylint: disable=no-member
+    # LLM provider selection: "openai" (default) or "nvidia_nim"
+    LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai")
 
-    # Model configuration for OpenAI's chat model
-    CHAT_MODEL = "gpt-4o-mini"
-
-    # Model configuration for OpenAI's Embeddings model
-    EMBED_MODEL = "text-embedding-3-small"
+    if LLM_PROVIDER == "nvidia_nim":
+        OPENAI_API_KEY = os.getenv("NVIDIA_API_KEY") or os.getenv("OPENAI_API_KEY")
+        OPENAI_API_BASE = os.getenv(
+            "OPENAI_API_BASE", "https://integrate.api.nvidia.com/v1"
+        )
+        CHAT_MODEL = os.getenv("CHAT_MODEL", "meta/llama-3.1-8b-instruct")
+        EMBED_MODEL = os.getenv("EMBED_MODEL", "nvidia/nv-embed-v1")
+        # NIM embedding models require input_type to distinguish passages from queries
+        EMBED_MODEL_KWARGS = {"input_type": "passage"}
+        QUERY_EMBED_MODEL_KWARGS = {"input_type": "query"}
+        # Smaller chunks improve retrieval recall on NIM models
+        CHUNK_SIZE = 256
+        CHUNK_OVERLAP = 25
+        # NIM cosine scores are lower than OpenAI's; tuned via benchmark
+        MIN_SIMILARITY = 0.30
+    else:
+        OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+        OPENAI_API_BASE = os.getenv("OPENAI_API_BASE")
+        CHAT_MODEL = os.getenv("CHAT_MODEL", "gpt-4o-mini")
+        EMBED_MODEL = os.getenv("EMBED_MODEL", "text-embedding-3-small")
+        EMBED_MODEL_KWARGS = {}
+        QUERY_EMBED_MODEL_KWARGS = {}
+        CHUNK_SIZE = 1024
+        CHUNK_OVERLAP = 50
+        MIN_SIMILARITY = 0.5
 
     # Maximum number of tokens for generating responses
     MAX_TOKENS = 1024
@@ -35,23 +55,14 @@ class Config:
     # Path to the PDF data file
     DATAPATH = "data/vm1kkye15yy2.pdf"
 
-    # RAG Model Chunk size
-    CHUNK_SIZE = 1024
-
-    # RAG Model Chunk overlap
-    CHUNK_OVERLAP = 50
-
     # Number of chunks to return from RAG Model
     TOP_K = 5
 
-    # Minimum cosine similarity to return from RAG Model
-    MIN_SIMILARITY = 0.5
-
     # Default system role message for the assistant
     SYSTEM_ROLE = """
-        Je bent een behulpzame assistant voor een politieambtenaar. 
-        Je hebt het Nieuwe Wetboek van Strafvordering tot je beschikking, waarmee je de gebruiker van waardevolle informatie kunt voorzien. 
-        Antwoord alleen op basis van de gegeven context. 
+        Je bent een behulpzame assistant voor een politieambtenaar.
+        Je hebt het Nieuwe Wetboek van Strafvordering tot je beschikking, waarmee je de gebruiker van waardevolle informatie kunt voorzien.
+        Antwoord alleen op basis van de gegeven context.
         Als het antwoord niet kan worden gevonden in de gegeven context, zeg dan dat je het antwoord niet weet.
         Antwoord in het Nederlands.
         """

--- a/models/rag_model.py
+++ b/models/rag_model.py
@@ -50,12 +50,38 @@ import faiss
 import numpy as np
 import tiktoken
 from langchain_openai import OpenAIEmbeddings
+from openai import OpenAI as OpenAIClient
 
 from config import Config
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
+
+
+class _NIMEmbeddings:
+    """
+    Thin embedding wrapper for NVIDIA NIM endpoints.
+    NIM embedding models require an `input_type` field passed via extra_body,
+    which LangChain's OpenAIEmbeddings does not support. This class uses the
+    OpenAI SDK directly so we can pass extra_body freely.
+    """
+
+    def __init__(self, api_key, base_url, model, extra_body=None):
+        self._client = OpenAIClient(api_key=api_key, base_url=base_url)
+        self._model = model
+        self._extra_body = extra_body or {}
+
+    def embed_query(self, text):
+        return self.embed_documents([text])[0]
+
+    def embed_documents(self, texts):
+        response = self._client.embeddings.create(
+            input=texts,
+            model=self._model,
+            extra_body=self._extra_body,
+        )
+        return [item.embedding for item in response.data]
 
 
 class RAGModel:
@@ -370,9 +396,18 @@ class RAGModel:
         """
         embeddings = []
         total_cost = 0.0  # To track the total cost of embeddings
-        embedding_model = OpenAIEmbeddings(
-            openai_api_key=self.api_key, model=Config.EMBED_MODEL
-        )
+        if Config.OPENAI_API_BASE and Config.EMBED_MODEL_KWARGS:
+            embedding_model = _NIMEmbeddings(
+                api_key=self.api_key,
+                base_url=Config.OPENAI_API_BASE,
+                model=Config.EMBED_MODEL,
+                extra_body=Config.EMBED_MODEL_KWARGS,
+            )
+        else:
+            embed_kwargs = {"openai_api_key": self.api_key, "model": Config.EMBED_MODEL}
+            if Config.OPENAI_API_BASE:
+                embed_kwargs["openai_api_base"] = Config.OPENAI_API_BASE
+            embedding_model = OpenAIEmbeddings(**embed_kwargs)
 
         encoding = tiktoken.get_encoding("cl100k_base")
         input_token_price = 0.02 / 1000000
@@ -428,10 +463,19 @@ class RAGModel:
         Returns:
         - indices (list): List of indices of the similar chunks meeting the similarity threshold.
         """
-        # Embed the query
-        embedding_model = OpenAIEmbeddings(
-            openai_api_key=self.api_key, model=Config.EMBED_MODEL
-        )
+        # Embed the query — use QUERY_EMBED_MODEL_KWARGS (input_type="query" for NIM)
+        if Config.OPENAI_API_BASE and Config.QUERY_EMBED_MODEL_KWARGS:
+            embedding_model = _NIMEmbeddings(
+                api_key=self.api_key,
+                base_url=Config.OPENAI_API_BASE,
+                model=Config.EMBED_MODEL,
+                extra_body=Config.QUERY_EMBED_MODEL_KWARGS,
+            )
+        else:
+            embed_kwargs = {"openai_api_key": self.api_key, "model": Config.EMBED_MODEL}
+            if Config.OPENAI_API_BASE:
+                embed_kwargs["openai_api_base"] = Config.OPENAI_API_BASE
+            embedding_model = OpenAIEmbeddings(**embed_kwargs)
         # Calculate the token cost for the query using "cl100k_base" encoding
         encoding = tiktoken.get_encoding("cl100k_base")
         input_tokens = encoding.encode(query)

--- a/utils/answer_generator.py
+++ b/utils/answer_generator.py
@@ -38,10 +38,9 @@ Dependencies:
 import logging
 
 from llama_index.core.llms import ChatMessage
-from llama_index.llms.openai import OpenAI
 
 from config import Config
-from utils.api import set_openai_api_key
+from utils.api import make_llm, set_openai_api_key
 from utils.citation_handler import get_direct_citation, is_direct_citation_request
 from utils.summarizer import summarize_history
 
@@ -137,9 +136,11 @@ def generate_answer(query, rag_model, conversation_history=None):
             for msg in messages:
                 logger.info("%s: %s", msg.role, msg.content[:200])
 
-            # Initialize the OpenAI chat model
-            llm = OpenAI(
-                temperature=0, model=Config.CHAT_MODEL, max_tokens=Config.MAX_TOKENS
+            # Initialize the chat model (NIM or OpenAI)
+            llm = make_llm(
+                temperature=0,
+                model=Config.CHAT_MODEL,
+                max_tokens=Config.MAX_TOKENS,
             )
 
             # Get the response from the chat model

--- a/utils/api.py
+++ b/utils/api.py
@@ -1,20 +1,22 @@
 """
 API Utility Module
 
-This module provides a utility function to configure the OpenAI API key for the ChatBot_DPC project.
-It retrieves the API key from the project's configuration (Config.OPENAI_API_KEY) and sets it for
-the OpenAI library, ensuring that subsequent API calls are properly authenticated.
+This module provides utilities for configuring and constructing LLM clients for the
+ChatBot_DPC project. It supports both the standard OpenAI provider (via LlamaIndex) and
+NVIDIA NIM endpoints (via the OpenAI SDK with a custom base URL).
 
 Functions:
-    set_openai_api_key():
-        Sets the OpenAI API key for the OpenAI library using the key defined in Config.
+    set_openai_api_key(): Sets the global OpenAI API key and optional base URL.
+    make_llm(temperature, model, max_tokens): Returns an LLM instance for the configured provider.
 
 Usage:
-    >>> from utils.api import set_openai_api_key
+    >>> from utils.api import set_openai_api_key, make_llm
     >>> set_openai_api_key()
+    >>> llm = make_llm(temperature=0, model="gpt-4o-mini", max_tokens=1024)
 """
 
 import openai
+from openai import OpenAI as OpenAIClient
 from config import Config
 
 
@@ -32,3 +34,96 @@ def set_openai_api_key():
         None
     """
     openai.api_key = Config.OPENAI_API_KEY
+    if Config.OPENAI_API_BASE:
+        openai.base_url = Config.OPENAI_API_BASE
+
+
+# ---------------------------------------------------------------------------
+# NIM-compatible chat wrappers
+# LlamaIndex's OpenAI class validates model names against OpenAI's known list,
+# which rejects NIM model names. These thin wrappers use the OpenAI SDK directly
+# and expose the same .chat(messages) interface that the rest of the code expects.
+# ---------------------------------------------------------------------------
+
+
+class _NIMMessage:  # pylint: disable=too-few-public-methods
+    """Mirrors LlamaIndex's ChatMessage.content interface."""
+
+    def __init__(self, content):
+        self.content = content
+
+
+class _NIMChatResponse:  # pylint: disable=too-few-public-methods
+    """Mirrors LlamaIndex's ChatResponse interface (.message.content and .raw.usage)."""
+
+    def __init__(self, raw):
+        self.raw = raw
+        self.message = _NIMMessage(raw.choices[0].message.content)
+
+
+class _NIMChatClient:  # pylint: disable=too-few-public-methods
+    """
+    Thin chat wrapper for NVIDIA NIM (and any OpenAI-compatible endpoint).
+    Exposes the same .chat(messages) interface as LlamaIndex's OpenAI class.
+    """
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(self, api_key, base_url, model, temperature, max_tokens):
+        self._client = OpenAIClient(api_key=api_key, base_url=base_url)
+        self._model = model
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+
+    def chat(self, messages):
+        """Send a chat request and return a response with .message.content and .raw.usage."""
+        messages_dict = [
+            {
+                "role": msg.role.value if hasattr(msg.role, "value") else str(msg.role),
+                "content": msg.content,
+            }
+            for msg in messages
+        ]
+        raw = self._client.chat.completions.create(
+            model=self._model,
+            messages=messages_dict,
+            temperature=self._temperature,
+            max_tokens=self._max_tokens,
+        )
+        return _NIMChatResponse(raw)
+
+
+def make_llm(temperature, model, max_tokens):
+    """
+    Construct an LLM client for the configured provider.
+
+    When OPENAI_API_BASE is set (i.e. NIM or another custom endpoint), returns a
+    _NIMChatClient that bypasses LlamaIndex's model-name validation. Otherwise
+    returns a standard LlamaIndex OpenAI instance.
+
+    Parameters:
+    - temperature (float): Sampling temperature.
+    - model (str): Model name.
+    - max_tokens (int): Maximum tokens to generate.
+
+    Returns:
+    - An LLM client with a .chat(messages) method.
+    """
+    if Config.OPENAI_API_BASE:
+        return _NIMChatClient(
+            api_key=Config.OPENAI_API_KEY,
+            base_url=Config.OPENAI_API_BASE,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+    # Lazy import: LlamaIndex is only needed for the standard OpenAI path.
+    # pylint: disable=import-outside-toplevel
+    from llama_index.llms.openai import OpenAI
+
+    return OpenAI(
+        temperature=temperature,
+        model=model,
+        max_tokens=max_tokens,
+        api_key=Config.OPENAI_API_KEY,
+    )

--- a/utils/summarizer.py
+++ b/utils/summarizer.py
@@ -19,9 +19,8 @@ Usage:
 
 import logging
 from llama_index.core.llms import ChatMessage
-from llama_index.llms.openai import OpenAI
 from config import Config
-from utils.api import set_openai_api_key
+from utils.api import make_llm, set_openai_api_key
 
 # Set up logging configuration
 logging.basicConfig(level=logging.INFO)
@@ -42,9 +41,11 @@ def summarize_history(history):
     # Set the OpenAI API key
     set_openai_api_key()
 
-    # Initialize the OpenAI chat model for summarization
-    llm = OpenAI(
-        temperature=0, model=Config.CHAT_MODEL, max_tokens=Config.SUMMARY_MAX_TOKENS
+    # Initialize the chat model (NIM or OpenAI)
+    llm = make_llm(
+        temperature=0,
+        model=Config.CHAT_MODEL,
+        max_tokens=Config.SUMMARY_MAX_TOKENS,
     )
 
     # Prepare the summarization prompt


### PR DESCRIPTION
## Summary
- Introduce `LLM_PROVIDER` env var (`openai` default or `nvidia_nim`) with provider-specific defaults for api key, base URL, chat model, embed model, chunk size, and similarity threshold
- Wrap the OpenAI SDK directly in `utils/api.py` and `models/rag_model.py` for the NIM path, since LlamaIndex's `OpenAI` rejects non-OpenAI model names and LangChain's `OpenAIEmbeddings` can't pass NIM's required `input_type` field
- Tuned NIM defaults via a retrieval benchmark across embed models and chunk configs: `nvidia/nv-embed-v1` (4096-dim) at chunk_size 256 / overlap 25 with `MIN_SIMILARITY=0.30`
- Add `.env.example` documenting both provider configurations

## Why these defaults
NIM cosine scores are systematically lower than OpenAI's for asymmetric retrieval. Benchmarked 3 NIM embed models × 4 chunk configs × 6 representative queries; the chosen combination is the only one that retrieved the correct chunk in the top-10 for all 6 test queries while keeping indexing cost manageable.

## Test plan
- [x] `pre-commit run --all-files` passes (black + pylint)
- [x] App boots end-to-end with `LLM_PROVIDER=nvidia_nim` and answers test query "Welke afdeling gaat over infiltratie?" correctly ("Afdeling 8.2.6 gaat over infiltratie.")
- [ ] Verify the OpenAI path still works for users without NIM credentials
- [ ] Smoke-test additional Dutch legal queries through the web UI